### PR TITLE
Circle-CI to build in Node LTS environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:lts
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Node 13 is breaking build. Changing Node version to ```node:lts```.